### PR TITLE
add comma to globi.json to make it valid json again

### DIFF
--- a/globi.json
+++ b/globi.json
@@ -1,5 +1,5 @@
 { 
   "_comment": "Bee (Anthophila) biotic interaction database.",
-  "citation": "Seltmann, Katja C. 2020. Biotic species interactions about bees (Anthophila) manually extracted from literature."
+  "citation": "Seltmann, Katja C. 2020. Biotic species interactions about bees (Anthophila) manually extracted from literature.",
   "deprecated": true
 }


### PR DESCRIPTION
Hi! Thanks for adding the "deprecated" option. Please accept this pull request to make the globi.json valid again (see comma on the citation line).